### PR TITLE
poster 파일 데이터 변경 

### DIFF
--- a/src/components/enrollment/EnrollPoster.tsx
+++ b/src/components/enrollment/EnrollPoster.tsx
@@ -1,52 +1,96 @@
 "use client";
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Plus } from "lucide-react";
 import { usePosterHandler } from "@/hooks/usePosterHandler";
+import { useEnrollmentData } from "@/hooks/useEnrollmentData";
+import { getImageURLIndexedDB } from "@/utils/Images";
+import { useDispatch } from "react-redux";
+import { setPoster } from "@/redux/slices/enrollSlice";
 
 interface EnrollPosterProps {
   isEdit?: boolean;
-  }
-  export default function EnrollPoster({isEdit = false}:EnrollPosterProps) {
-    const { fileName, previewPoster, handleFileChange } = usePosterHandler({
+}
+export default function EnrollPoster({ isEdit = false }: EnrollPosterProps) {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [loadedPoster, setLoadedPoster] = useState<boolean>(false);
+  const { poster } = useEnrollmentData({ isEdit });
+  const { fileName, previewPoster, handleFileChange } = usePosterHandler({
     isEditMode: isEdit,
   });
 
-    const handleOnFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files ? e.target.files[0] : null
-      await handleFileChange(file)
+  const handleOnFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files ? e.target.files[0] : null;
+    await handleFileChange(file);
+  };
+
+  const isInitialLoad = useRef(true); // 초기 로딩 여부 추적
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const relaceImageURL = async () => {
+      const targetKey = poster?.fileKey;
+      try {
+        if (targetKey) {
+          const newPosterURL = await getImageURLIndexedDB(targetKey);
+          const newPoster = {
+            fileKey: poster.fileKey,
+            fileName: poster.fileName,
+            fileSize: poster.fileSize,
+            fileType: poster.fileType,
+            url: newPosterURL,
+          };
+          dispatch(setPoster(newPoster));
+        }
+      } catch (error) {
+        console.error(
+          "새로운 포스터 URL 이미지를 받아오는데 실패했습니다",
+          error
+        );
+      }
+    };
+    if (poster) {
+      setLoadedPoster(true);
     }
- 
-    return (
-      <>
-        <div className="relative lg:h-full w-full flex">
-          <div className="w-full h-full border-2 hidden lg:block">
-            {previewPoster && (
-              <img
-                className="w-[380px] h-[520px] object-cover aspec-[270/210]"
-                src={previewPoster}
-                alt="포스터 미리보기"
-              />
-            )}
-          </div>
+    if (isInitialLoad.current && loadedPoster) {
+      relaceImageURL();
+      isInitialLoad.current = false;
+    }
+  }, [dispatch, isInitialLoad, loadedPoster, poster]);
 
-          <div className="border-2 rounded-lg px-4 py-2 flex-1 w-full bg-background lg:hidden">
-            {fileName ? fileName : "파일을 선택하세요"}
-          </div>
-          <label
-            className="flex justify-center items-center  rounded-md lg:w-[36px] lg:aspect-[1/1] lg:rounded-full lg:absolute lg:bottom-5 lg:right-5 lg:bg-flesh-500 lg:z-100  cursor-pointer lg:hover:bg-flesh-700 transition"
-            htmlFor="poster"
-          >
-            <Plus className="lg:stroke-white" strokeWidth={3} />
-          </label>
-
-          <input
-            className="sr-only"
-            id="poster"
-            name="poster"
-            type="file"
-            onChange={handleOnFileChange}
-          />
+  return (
+    <>
+      <div className="relative lg:h-full w-full flex">
+        <div className="w-full h-full border-2 hidden lg:block">
+          {previewPoster && (
+            <img
+              className="w-[380px] h-[520px] object-cover aspec-[270/210]"
+              src={previewPoster}
+              data-key={`${poster?.fileKey}`}
+              alt="포스터 미리보기"
+              ref={imgRef}
+            />
+          )}
         </div>
-      </>
-    );
-  }
+
+        <div className="border-2 rounded-lg px-4 py-2 flex-1 w-full bg-background lg:hidden">
+          {fileName ? fileName : "파일을 선택하세요"}
+        </div>
+        <label
+          className="flex justify-center items-center  rounded-md lg:w-[36px] lg:aspect-[1/1] lg:rounded-full lg:absolute lg:bottom-5 lg:right-5 lg:bg-flesh-500 lg:z-100  cursor-pointer lg:hover:bg-flesh-700 transition"
+          htmlFor="poster"
+        >
+          <Plus className="lg:stroke-white" strokeWidth={3} />
+        </label>
+
+        <input
+          className="sr-only"
+          id="poster"
+          name="poster"
+          type="file"
+          onChange={handleOnFileChange}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/enrollment/write/EnrollFooter.tsx
+++ b/src/components/enrollment/write/EnrollFooter.tsx
@@ -24,6 +24,7 @@ export default function EnrollFooter() {
   const enrollResult = useSelector((state: RootState) => state.enroll);
   const seatResult = useSelector((state: RootState) => state.seat);
   const imageFiles = enrollResult.files;
+  const poster = enrollResult.poster;
   const isDirty = enrollResult.isDirty || seatResult.isDirty;
   const { isValid, invalidFieldName } = useValidationEnrollment({
     enroll: enrollResult,
@@ -87,11 +88,18 @@ export default function EnrollFooter() {
     return files;
   };
 
+  const getPosterFileIndexedDB = async () => {
+    if (poster && poster.fileKey) {
+      const files = await getImage(poster?.fileKey);
+      return files;
+    }
+  };
+
   const handleSubmit = async () => {
     setLoading(true);
     try {
       const imagefiles = await getImageFileIndexedDB();
-
+      const posterfile = await getPosterFileIndexedDB();
       const formData = new FormData();
 
       imagefiles.forEach((file) => {
@@ -106,6 +114,15 @@ export default function EnrollFooter() {
           formData.append(`image`, newfile);
         }
       });
+
+      if (posterfile && posterfile.imageData) {
+        const newFile = new File(
+          [posterfile.imageData],
+          `${posterfile.id}_${posterfile.title}`,
+          { type: posterfile.imageType }
+        );
+        formData.append("poster", newFile);
+      }
 
       const { files: _files, ...rest } = {
         ...enrollResult,

--- a/src/components/enrollment/write/EnrollFooter.tsx
+++ b/src/components/enrollment/write/EnrollFooter.tsx
@@ -5,8 +5,8 @@ import {
   setInvalidField,
   setStep,
 } from "@/redux/slices/enrollSlice";
-import { RootState } from "@/redux/store";
-import { getImage } from "@/services/indexedDBService";
+import { persistor, RootState } from "@/redux/store";
+import { clearAllImages, getImage } from "@/services/indexedDBService";
 import { EnrollStep } from "@/types/enrollment";
 import axios from "axios";
 import React, { useState } from "react";
@@ -139,6 +139,8 @@ export default function EnrollFooter() {
 
       if (response.status === 201) {
         alert("공연 등록이 완료되었습니다.");
+        persistor.purge();
+        await clearAllImages();
         router.push("/manager/performance");
       }
     } catch (error) {

--- a/src/hooks/usePosterHandler.ts
+++ b/src/hooks/usePosterHandler.ts
@@ -4,61 +4,65 @@ import { useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useEnrollSelector } from "./useEnrollSelector";
 import { useEnrollEditSelector } from "./useEditEnrollSelector";
+import { getImageURLIndexedDB, saveImageIndexedDB } from "@/utils/Images";
+import { deleteImage } from "@/services/indexedDBService";
 
 interface UsePosterHandlerProps {
-    isEditMode: boolean;
+  isEditMode: boolean;
 }
 
-interface UsePosterHandlerResult  {
-    fileName: string;
-    previewPoster: string | undefined;
-    handleFileChange: (file: File | null) => Promise<void>;
+interface UsePosterHandlerResult {
+  fileName: string;
+  previewPoster: string | undefined;
+  handleFileChange: (file: File | null) => Promise<void>;
 }
 
-const imageToBase64 = (file: File): Promise<string> => {
-    return new Promise((res) => {
-        const blob = new Blob([file], { type: file.type });
-        const reader = new FileReader();
-        reader.readAsDataURL(blob);
-        reader.onloadend = () => {
-            const base64String = reader.result;
-            res(base64String as string);
-        };
-    });
+export const usePosterHandler = ({
+  isEditMode = false,
+}: UsePosterHandlerProps): UsePosterHandlerResult => {
+  const [fileName, setFileName] = useState<string>("");
+  const { poster: enrollPoster } = useEnrollSelector();
+  const { editPoster } = useEnrollEditSelector();
+  const dispatch = useDispatch();
+  const poster = isEditMode ? editPoster : enrollPoster;
+  const previewPoster = poster?.url;
+
+  const handleFileChange = useCallback(
+    async (file: File | null) => {
+      if (file) {
+        try {
+          if (poster && poster.fileKey) {
+            await deleteImage(poster.fileKey);
+          }
+          const fileId = await saveImageIndexedDB(file);
+          const imageUrl = await getImageURLIndexedDB(fileId);
+          setFileName(file.name);
+          const posterData = {
+            fileKey: fileId,
+            fileName: file.name,
+            fileSize: file.size,
+            fileType: file.type,
+            url: imageUrl,
+          };
+          if (isEditMode) {
+            dispatch(setEditPoster(posterData));
+          } else {
+            dispatch(setPoster(posterData));
+          }
+        } catch (error) {
+          console.error("포스터 업로드에 실패했습니다", error);
+          setFileName("");
+          if (isEditMode) {
+            dispatch(setEditPoster(null));
+          } else {
+            dispatch(setPoster(null));
+          }
+          alert("포스터 업로드에 실패했습니다.");
+        }
+      }
+    },
+    [dispatch, isEditMode, poster]
+  );
+
+  return { fileName, previewPoster, handleFileChange };
 };
-
-
-export const usePosterHandler = ({ isEditMode = false}: UsePosterHandlerProps): UsePosterHandlerResult => {
-    const [fileName, setFileName] = useState<string>("");
-    const { poster: enrollPoster } = useEnrollSelector()
-    const { editPoster } = useEnrollEditSelector();  
-    const dispatch = useDispatch();
-    const poster = isEditMode ? editPoster : enrollPoster;
-    const previewPoster = poster?.url
-
-    const handleFileChange = useCallback(async (file: File | null) => {
-    if (file) {
-      const base64File = await imageToBase64(file);
-      setFileName(file.name);
-      const posterData = {
-        fileName: file.name,
-        fileSize: file.size,
-        fileType: file.type,
-        url: base64File,
-      };
-      if (isEditMode) {
-        dispatch(setEditPoster(posterData));
-      } else {
-        dispatch(setPoster(posterData));
-      }
-    } else {
-      setFileName("");
-      if (isEditMode) {
-        dispatch(setEditPoster(null));
-      } else {
-        dispatch(setPoster(null));
-      }
-    }
-  }, [dispatch, isEditMode]);
-   return { fileName, previewPoster, handleFileChange };
-}

--- a/src/hooks/useValidationEnrollment.ts
+++ b/src/hooks/useValidationEnrollment.ts
@@ -31,7 +31,7 @@ export function useValidationEnrollment({
       !!fileType &&
       !!url &&
       fileSize > 0 &&
-      /^data:image\/[a-z]+;base64/
+      /^blob:/.test(url)
     );
   };
 

--- a/src/types/file.ts
+++ b/src/types/file.ts
@@ -1,5 +1,5 @@
 export interface ImageFile {
-  fileKey?: number;
+  fileKey?: string;
   fileName: string;
   fileSize: number;
   fileType: string;


### PR DESCRIPTION
포스터 이미지를 base64URL 을 사용할 경우 고해상도 이미지시 오류가 발생하여 blobURL을 사용하여 미리보기를 제공하고 fileData로 넘기게 수정했습니다.
공연 등록 및 불러오기 하지 않을 시 indexedDB와 persist 데이터에서 삭제하는 로직을 추가했습니다.